### PR TITLE
fix dependency order of soy templates

### DIFF
--- a/boilerplates/boilerplate-soy/5. Modal - Nested Components/src/CloseHeader.js
+++ b/boilerplates/boilerplate-soy/5. Modal - Nested Components/src/CloseHeader.js
@@ -1,4 +1,4 @@
-import templates from './CloseHeader.soy';
+import templates from './CloseHeader.soy.js';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
 

--- a/boilerplates/boilerplate-soy/5. Modal - Nested Components/src/Modal.js
+++ b/boilerplates/boilerplate-soy/5. Modal - Nested Components/src/Modal.js
@@ -1,5 +1,5 @@
 import './modal.scss';
-import './CloseHeader.soy.js';
+import './CloseHeader.js';
 import templates from './Modal.soy.js';
 import Component from 'metal-component';
 import Soy from 'metal-soy';

--- a/boilerplates/boilerplate-soy/5. Modal - Nested Components/src/Modal.js
+++ b/boilerplates/boilerplate-soy/5. Modal - Nested Components/src/Modal.js
@@ -1,4 +1,5 @@
 import './modal.scss';
+import './CloseHeader.soy.js';
 import templates from './Modal.soy.js';
 import Component from 'metal-component';
 import Soy from 'metal-soy';

--- a/boilerplates/boilerplate-soy/6. Modal - Testing/src/CloseHeader.js
+++ b/boilerplates/boilerplate-soy/6. Modal - Testing/src/CloseHeader.js
@@ -1,4 +1,4 @@
-import templates from './CloseHeader.soy';
+import templates from './CloseHeader.soy.js';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
 

--- a/boilerplates/boilerplate-soy/6. Modal - Testing/src/Modal.js
+++ b/boilerplates/boilerplate-soy/6. Modal - Testing/src/Modal.js
@@ -1,5 +1,5 @@
 import './modal.scss';
-import './CloseHeader.soy.js';
+import './CloseHeader.js';
 import templates from './Modal.soy.js';
 import Component from 'metal-component';
 import Soy from 'metal-soy';

--- a/boilerplates/boilerplate-soy/6. Modal - Testing/src/Modal.js
+++ b/boilerplates/boilerplate-soy/6. Modal - Testing/src/Modal.js
@@ -1,4 +1,5 @@
 import './modal.scss';
+import './CloseHeader.soy.js';
 import templates from './Modal.soy.js';
 import Component from 'metal-component';
 import Soy from 'metal-soy';


### PR DESCRIPTION
### Disclaimer
Reported issue claims the `5. Modal - Nested Components` example project throws an error. For further information see https://github.com/metal/metal-examples/issues/4.

### Intent
To fix the issue above by adding the required soy dependencies.

### Solution
- External soy template is compiled but never placed into the generated bundle due to an absence of any reference to it. 
- Regenerated the archives and added another PR to the metaljs.com project

### Test
Tested in Chrome (latest) and the example now works as expected.